### PR TITLE
Fix downloading without an extraction directory

### DIFF
--- a/src/main/java/vazkii/cmpdl/CMPDL.java
+++ b/src/main/java/vazkii/cmpdl/CMPDL.java
@@ -215,16 +215,18 @@ public final class CMPDL {
     public static void extractModpackMetadata(Path zipFile, Path extractDir) throws IOException {
         Interface.setStatus("Unzipping Modpack Download");
 
-        log("Cleaning up extract dir");
-        Files.walk(extractDir)
-                .sorted(Comparator.reverseOrder())
-                .forEachOrdered(path -> {
-                    try {
-                        Files.deleteIfExists(path);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                });
+        if (Files.exists(extractDir)) {
+            log("Cleaning up extract dir");
+            Files.walk(extractDir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEachOrdered(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+        }
 
         log("Unzipping file");
         try (FileSystem zipFs = FileSystems.newFileSystem(zipFile, (ClassLoader) null)) {


### PR DESCRIPTION
If the extraction directory doesn't exist then Files#walk will crash trying to get the attributes of a non-existent path:

```
Error: class java.nio.file.NoSuchFileException: ~/.cmpdl/All of Fabric 3-2.0.2
sun.nio.fs.WindowsException.translateToIOException(Unknown Source)
sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
sun.nio.fs.WindowsException.rethrowAsIOException(Unknown Source)
sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(Unknown Source)
sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(Unknown Source)
sun.nio.fs.WindowsFileSystemProvider.readAttributes(Unknown Source)
java.nio.file.Files.readAttributes(Unknown Source)
java.nio.file.FileTreeWalker.getAttributes(Unknown Source)
java.nio.file.FileTreeWalker.visit(Unknown Source)
java.nio.file.FileTreeWalker.walk(Unknown Source)
java.nio.file.FileTreeIterator.<init>(Unknown Source)
java.nio.file.Files.walk(Unknown Source)
java.nio.file.Files.walk(Unknown Source)
vazkii.cmpdl.CMPDL.extractModpackMetadata(CMPDL.java:219)
vazkii.cmpdl.CMPDL.downloadModpackMetadata(CMPDL.java:186)
vazkii.cmpdl.CMPDL.downloadFromURL(CMPDL.java:92)
vazkii.cmpdl.OperatorThread.run(OperatorThread.java:30)
```